### PR TITLE
feedbackfixx

### DIFF
--- a/src/sass/сomponents/_feedback.scss
+++ b/src/sass/сomponents/_feedback.scss
@@ -1,6 +1,10 @@
 body {
   background-color: $colorBgBose;
 }
+.feedback {
+  padding-bottom: 72px;
+}
+
 .feedback__container {
   display: flex;
   flex-direction: column;
@@ -256,6 +260,9 @@ body {
     gap: 52px;
   }
 }
+.feedback {
+  padding-bottom: 100px;
+}
 .feedback__title {
   font-size: 30px;
 }
@@ -274,7 +281,9 @@ body {
     gap: 150px;
     justify-content: space-between;
   }
-
+  .feedback {
+    padding-bottom: 170px;
+  }
   .feedback__help {
     max-width: 350px;
     gap: 50px;
@@ -286,6 +295,7 @@ body {
 
   .feedback__text {
     font-size: 28px;
+    max-width: 400px;
   }
 
   .feedback__form {


### PR DESCRIPTION
Завершив:
Перевірити html на валідаторі

Виправити стилі абзацу feedback__text в секції feedback, тому що вони відрізняються від макету

Виправити відступ між footer та feedback на різних версіях

Секціяbanner на цій версії має відступи зліва та справа, якщо точніше - ці відступу повинен мати її контейнер